### PR TITLE
1.0.1

### DIFF
--- a/_config/postcss.config.js
+++ b/_config/postcss.config.js
@@ -7,6 +7,8 @@ module.exports = (file, options, env) => {
 
 	if (typeof file.env !== 'undefined' && file.env === 'scss') {
 
+		// Scss Processing
+
 		config.syntax = 'postcss-scss';
 
 		config.plugins = {
@@ -27,7 +29,26 @@ module.exports = (file, options, env) => {
 			}
 		};
 
+	} else if (typeof file.env !== 'undefined' && file.env === 'csspre') {
+
+		// CSS Pre-processing
+
+		config.plugins = {
+			'autoprefixer': {
+				browsers: [
+					'> 5% in US',
+					'last 2 versions',
+					'Firefox ESR',
+					'IE >= 8',
+					'iOS >= 8'
+				],
+				remove: false
+			}
+		};
+
 	} else {
+
+		// CSS Post-processing
 
 		config.plugins = {
 			'postcss-pxtorem': {
@@ -47,17 +68,7 @@ module.exports = (file, options, env) => {
 					'width'
 				]
 			},
-			'autoprefixer': {
-				browsers: [
-					'> 5% in US',
-					'last 2 versions',
-					'Firefox ESR',
-					'IE >= 8',
-					'iOS >= 8'
-				],
-				remove: false
-			},
-			'cssnano': false
+			'cssnano': true
 		};
 
 	}

--- a/app/ejs/lib/foundation.js
+++ b/app/ejs/lib/foundation.js
@@ -1,0 +1,2 @@
+import { Foundation } from 'foundation-sites';
+window.Foundation = Foundation;

--- a/app/ejs/main.js
+++ b/app/ejs/main.js
@@ -1,10 +1,12 @@
 import './lib/jquery.js';
-import { Foundation } from 'foundation-sites';
+import './lib/foundation.js';
 
-const ready = () => console.log('Hello, BarkleyREI!');
+const ready = () => {
+
+	console.log('Hello, BarkleyREI!');
+
+};
 
 window.addEventListener('DOMContentLoaded', ready, false);
-
-console.log(Foundation);
 
 $(document).foundation();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "brei-project-scaffold",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Client project by BarkleyREI",
 	"author": {
 		"name": "BarkleyREI"
@@ -70,8 +70,8 @@
 		"deploy": "npm run clean:deploy && node lib/copy.js --deploy",
 		"modernizr": "customizr -c ./_config/modernizr-config.json",
 		"postcss:fixsass": "postcss --config _config/ -r app/scss/**/*.scss --env=scss",
-		"postcss:postprocess": "postcss --config _config/ -r dist/css/main.css --env=css",
-		"postcss:preprocess": "postcss --config _config/ -r app/css/main.css --env=css",
+		"postcss:postprocess": "postcss --config _config/ -r dist/css/main.css --env=csspost",
+		"postcss:preprocess": "postcss --config _config/ -r app/css/main.css --env=csspre",
 		"preprocess": "npm run preprocess:css && npm run preprocess:js && npm run modernizr",
 		"preprocess:css": "npm run sass:build && npm run postcss:preprocess",
 		"preprocess:js": "npx webpack --config ./_config/webpack.config.js",

--- a/test/test.js
+++ b/test/test.js
@@ -37,6 +37,7 @@ let valid = [
 				ejs: [
 					{
 						lib: [
+							'foundation.js',
 							'jquery.js'
 						]
 					},


### PR DESCRIPTION
# Version 1.0.1

Fix SCSS processing and some EJS Lint issues.

## Changes

- Fix: Fixed lint errors complaining about unused Foundation variables by restructuring library so that Foundation is added to the window by default, similar to jQuery.
- Fix: Adjusted SCSS Pre- and Post-Processing so that when the Server is run, pixel values are shown, but when compiled, everything is converted to rem.
